### PR TITLE
Make non-return Kevins + UNRK reskinnable

### DIFF
--- a/Ahorn/entities/nonReturnKevin.jl
+++ b/Ahorn/entities/nonReturnKevin.jl
@@ -4,7 +4,7 @@ module CH_NonReturnKevin
 using ..Ahorn, Maple
 
 
-@mapdef Entity "CherryHelper/NonReturnKevin" NonReturnCrushBlock(x::Integer, y::Integer, width::Integer=32, height::Integer=32, axes::String="both", chillout::Bool=false, altTexture::Bool=false)
+@mapdef Entity "CherryHelper/NonReturnKevin" NonReturnCrushBlock(x::Integer, y::Integer, width::Integer=32, height::Integer=32, axes::String="both", chillout::Bool=false, spriteDirectory::String="objects/noReturnKevin", fillColor::String="242262")
 
 
 const placements = Ahorn.PlacementDict(
@@ -12,22 +12,21 @@ const placements = Ahorn.PlacementDict(
        NonReturnCrushBlock,
         "rectangle",
         Dict{String, Any}(
-            "altTexture" => false
+            "spriteDirectory" => "objects/crushblock",
+            "fillColor" => "62222b"
         )
     ),
     "Non-Return Kevin (Resprite) (Cherry Helper)" => Ahorn.EntityPlacement(
        NonReturnCrushBlock,
         "rectangle",
         Dict{String, Any}(
-            "altTexture" => true
+            "spriteDirectory" => "objects/noReturnKevin",
+            "fillColor" => "242262"
         )
     ),
 )
 
 
-
-const kevinColor = (98, 34, 43) ./ 255
-const altKevinColor = (36, 34, 98) ./ 255
 Ahorn.editingOptions(entity::NonReturnCrushBlock) = Dict{String, Any}(
     "axes" => Maple.kevin_axes
 )
@@ -39,7 +38,16 @@ Ahorn.selection(entity::NonReturnCrushBlock) = Ahorn.getEntityRectangle(entity)
 
 # Todo - Use randomness to decide on Kevin border
 function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::NonReturnCrushBlock, room::Maple.Room)
-    restrainedTex = (get(entity.data, "altTexture", false) ? "objects/noReturnKevin" : "objects/crushblock")
+    # Backwards compatibility for alt texture toggle
+    if (get(entity.data, "altTexture", true))
+        restrainedTex = get(entity.data, "spriteDirectory", "objects/noReturnKevin")
+        fillColor = get(entity.data, "fillColor", "242262")
+    else
+        restrainedTex = "objects/crushblock"
+        fillColor = "62222b"
+    end
+
+    kevinColor = Ahorn.argb32ToRGBATuple(parse(Int, fillColor, base=16))[1:3] ./ 255
 
     frameImage = Dict{String, String}(
         "none" => string(restrainedTex, "/block00"),
@@ -66,7 +74,7 @@ function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::NonReturnCrushBlock
     tilesWidth = div(width, 8)
     tilesHeight = div(height, 8)
 
-    Ahorn.drawRectangle(ctx, 2, 2, width - 4, height - 4, (get(entity.data, "altTexture", false) ?  altKevinColor : kevinColor))
+    Ahorn.drawRectangle(ctx, 2, 2, width - 4, height - 4, kevinColor)
     Ahorn.drawImage(ctx, faceSprite, div(width - faceSprite.width, 2), div(height - faceSprite.height, 2))
 
     for i in 2:tilesWidth - 1

--- a/Ahorn/entities/uninterruptedNonReturnKevin.jl
+++ b/Ahorn/entities/uninterruptedNonReturnKevin.jl
@@ -4,7 +4,7 @@ module CH_UninterruptedNonReturnKevin
 using ..Ahorn, Maple
 
 
-@mapdef Entity "CherryHelper/UI_NRCB" UninterruptedNRCB(x::Integer, y::Integer, width::Integer=32, height::Integer=32, axes::String="both", chillout::Bool=false, altTexture::Bool=false)
+@mapdef Entity "CherryHelper/UI_NRCB" UninterruptedNRCB(x::Integer, y::Integer, width::Integer=32, height::Integer=32, axes::String="both", chillout::Bool=false, spriteDirectory::String="objects/uninterruptedNRK", fillColor::String="242262")
 
 
 const placements = Ahorn.PlacementDict(
@@ -12,22 +12,21 @@ const placements = Ahorn.PlacementDict(
        UninterruptedNRCB,
         "rectangle",
         Dict{String, Any}(
-            "altTexture" => false
+            "spriteDirectory" => "objects/crushblock",
+            "fillColor" => "62222b"
         )
     ),
     "Uninterruptable Non-Return Kevin (Resprite) (Cherry Helper)" => Ahorn.EntityPlacement(
        UninterruptedNRCB,
         "rectangle",
         Dict{String, Any}(
-            "altTexture" => true
+            "spriteDirectory" => "objects/uninterruptedNRK",
+            "fillColor" => "242262"
         )
     ),
 )
 
 
-
-const kevinColor = (98, 34, 43) ./ 255
-const altKevinColor = (36, 34, 98) ./ 255
 Ahorn.editingOptions(entity::UninterruptedNRCB) = Dict{String, Any}(
     "axes" => Maple.kevin_axes
 )
@@ -39,7 +38,16 @@ Ahorn.selection(entity::UninterruptedNRCB) = Ahorn.getEntityRectangle(entity)
 
 # Todo - Use randomness to decide on Kevin border
 function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::UninterruptedNRCB, room::Maple.Room)
-    restrainedTex = (get(entity.data, "altTexture", false) ? "objects/uninterruptedNRK" : "objects/crushblock")
+    # Backwards compatibility for alt texture toggle
+    if (get(entity.data, "altTexture", true))
+        restrainedTex = get(entity.data, "spriteDirectory", "objects/uninterruptedNRK")
+        fillColor = get(entity.data, "fillColor", "242262")
+    else
+        restrainedTex = "objects/crushblock"
+        fillColor = "62222b"
+    end
+
+    kevinColor = Ahorn.argb32ToRGBATuple(parse(Int, fillColor, base=16))[1:3] ./ 255
 
     frameImage = Dict{String, String}(
         "none" => string(restrainedTex, "/block00"),
@@ -66,7 +74,7 @@ function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::UninterruptedNRCB, 
     tilesWidth = div(width, 8)
     tilesHeight = div(height, 8)
 
-    Ahorn.drawRectangle(ctx, 2, 2, width - 4, height - 4, (get(entity.data, "altTexture", false) ?  altKevinColor : kevinColor))
+    Ahorn.drawRectangle(ctx, 2, 2, width - 4, height - 4, kevinColor)
     Ahorn.drawImage(ctx, faceSprite, div(width - faceSprite.width, 2), div(height - faceSprite.height, 2))
 
     for i in 2:tilesWidth - 1

--- a/Code/Entities/NonReturnCrushBlock.cs
+++ b/Code/Entities/NonReturnCrushBlock.cs
@@ -10,12 +10,25 @@ namespace Celeste.Mod.CherryHelper
     [CustomEntity("CherryHelper/NonReturnKevin")]
     public class NonReturnCrushBlock : Solid
     {
-
-        public NonReturnCrushBlock(Vector2 position, float width, float height, Axes axes, bool chillOut = false, bool altTexture = false) : base(position, width, height, false)
+        private string spriteDirectory;
+        public NonReturnCrushBlock(EntityData data, Vector2 offset) : base(data.Position + offset, data.Width, data.Height, false)
         {
-            this.altTexture = altTexture;
-            this.fill = altTexture ? Calc.HexToColor("242262") : Calc.HexToColor("62222b");
-            altTextureString = (altTexture ? "objects/noReturnKevin/" : "objects/crushblock/");
+            axes = data.Enum("axes", Axes.Both);
+            chillOut = data.Bool("chillOut", false);
+
+            // Backwards compatibility for toggled texture
+            altTexture = data.Bool("altTexture", true);
+            if (altTexture)
+            {
+                spriteDirectory = data.Attr("spriteDirectory", "objects/noReturnKevin");
+                fill = Calc.HexToColor(data.Attr("fillColor", "242262"));
+            }
+            else
+            {
+                spriteDirectory = "objects/crushblock";
+                fill = Calc.HexToColor("62222b");
+            }
+
             this.idleImages = new List<Image>();
             this.activeTopImages = new List<Image>();
             this.activeRightImages = new List<Image>();
@@ -23,13 +36,12 @@ namespace Celeste.Mod.CherryHelper
             this.activeBottomImages = new List<Image>();
             this.OnDashCollide = new DashCollision(this.OnDashed);
             this.returnStack = new List<NonReturnCrushBlock.MoveState>();
-            this.chillOut = chillOut;
             this.giant = (Width >= 48f && Height >= 48f && chillOut);
             this.canActivate = true;
             this.attackCoroutine = new Coroutine(true);
             this.attackCoroutine.RemoveOnComplete = false;
             Add(this.attackCoroutine);
-            List<MTexture> atlasSubtextures = GFX.Game.GetAtlasSubtextures(altTextureString + "block");
+            List<MTexture> atlasSubtextures = GFX.Game.GetAtlasSubtextures(spriteDirectory + "/block");
             MTexture idle;
             switch (axes)
             {
@@ -48,16 +60,42 @@ namespace Celeste.Mod.CherryHelper
                     this.canMoveVertically = true;
                     break;
             }
-            if (altTexture)
+            Add(face = new Sprite(GFX.Game, spriteDirectory + "/"));
+            if (giant)
             {
-                Add(this.face = GFX.SpriteBank.Create(this.giant ? "giant_NoReturnKevin_face" : "NoReturnKevin_face"));
+                /*
+                  <Loop id="idle" path="giant_block" frames="0" delay="0.08"/>
+                  <Anim id="hurt"  path="giant_block" frames="8-12" delay="0.08" goto="idle"/>
+                  <Anim id="hit" path="giant_block" frames="0-5" delay="0.08"/>
+                  <Loop id="right" path="giant_block" frames="6,7"  delay="0.08"/>
+                */
+                face.AddLoop("idle", "giant_block", 0.08f, 0);
+                face.Add("hurt", "giant_block", 0.08f, "idle", 8, 9, 10, 11, 12);
+                face.Add("hit", "giant_block", 0.08f, 0, 1, 2, 3, 4, 5);
+                face.AddLoop("right", "giant_block", 0.08f, 6, 7);
             }
             else
             {
-                Add(this.face = GFX.SpriteBank.Create(this.giant ? "giant_crushblock_face" : "crushblock_face"));
+                /*
+                  <Loop id="idle" path="idle_face" delay="0.08"/>
+                  <Anim id="hurt" path="hurt" frames="3-12" delay="0.08" goto="idle"/>
+                  <Anim id="hit" path="hit" delay="0.08"/>
+                  <Loop id="left" path="hit_left" delay="0.08"/>
+                  <Loop id="right" path="hit_right" delay="0.08"/>
+                  <Loop id="up" path="hit_up" delay="0.08"/>
+                  <Loop id="down" path="hit_down" delay="0.08"/>
+                */
+
+                face.AddLoop("idle", "idle_face", 0.08f);
+                face.Add("hurt", "hurt", 0.08f, "idle", 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+                face.Add("hit", "hit", 0.08f);
+                face.AddLoop("left", "hit_left", 0.08f);
+                face.AddLoop("right", "hit_right", 0.08f);
+                face.AddLoop("up", "hit_up", 0.08f);
+                face.AddLoop("down", "hit_down", 0.08f);
             }
-            this.face.Position = new Vector2(Width, Height) / 2f;
-            this.face.Play("idle", false, false);
+            face.CenterOrigin();
+            face.Play("idle");
             this.face.OnLastFrame = delegate (string f)
             {
                 bool flag = f == "hit";
@@ -85,10 +123,6 @@ namespace Celeste.Mod.CherryHelper
             Add(new LightOcclude(0.2f));
             Add(this.returnLoopSfx = new SoundSource());
             Add(new WaterInteraction(() => this.crushDir != Vector2.Zero));
-        }
-
-        public NonReturnCrushBlock(EntityData data, Vector2 offset) : this(data.Position + offset, (float)data.Width, (float)data.Height, data.Enum<NonReturnCrushBlock.Axes>("axes", Axes.Both), data.Bool("chillout", false), data.Bool("altTexture", false))
-        {
         }
 
         public override void Added(Scene scene)
@@ -191,7 +225,7 @@ namespace Celeste.Mod.CherryHelper
                 bool flag4 = borderX < 0;
                 if (flag4)
                 {
-                    Image image2 = new Image(GFX.Game[altTextureString + "lit_left"].GetSubtexture(0, ty * 8, 8, 8, null));
+                    Image image2 = new Image(GFX.Game[spriteDirectory + "/lit_left"].GetSubtexture(0, ty * 8, 8, 8, null));
                     this.activeLeftImages.Add(image2);
                     image2.Position = vector;
                     image2.Visible = false;
@@ -202,7 +236,7 @@ namespace Celeste.Mod.CherryHelper
                     bool flag5 = borderX > 0;
                     if (flag5)
                     {
-                        Image image3 = new Image(GFX.Game[altTextureString + "lit_right"].GetSubtexture(0, ty * 8, 8, 8, null));
+                        Image image3 = new Image(GFX.Game[spriteDirectory + "/lit_right"].GetSubtexture(0, ty * 8, 8, 8, null));
                         this.activeRightImages.Add(image3);
                         image3.Position = vector;
                         image3.Visible = false;
@@ -212,7 +246,7 @@ namespace Celeste.Mod.CherryHelper
                 bool flag6 = borderY < 0;
                 if (flag6)
                 {
-                    Image image4 = new Image(GFX.Game[altTextureString + "lit_top"].GetSubtexture(tx * 8, 0, 8, 8, null));
+                    Image image4 = new Image(GFX.Game[spriteDirectory + "/lit_top"].GetSubtexture(tx * 8, 0, 8, 8, null));
                     this.activeTopImages.Add(image4);
                     image4.Position = vector;
                     image4.Visible = false;
@@ -223,7 +257,7 @@ namespace Celeste.Mod.CherryHelper
                     bool flag7 = borderY > 0;
                     if (flag7)
                     {
-                        Image image5 = new Image(GFX.Game[altTextureString + "lit_bottom"].GetSubtexture(tx * 8, 0, 8, 8, null));
+                        Image image5 = new Image(GFX.Game[spriteDirectory + "/lit_bottom"].GetSubtexture(tx * 8, 0, 8, 8, null));
                         this.activeBottomImages.Add(image5);
                         image5.Position = vector;
                         image5.Visible = false;
@@ -768,7 +802,7 @@ namespace Celeste.Mod.CherryHelper
         // Token: 0x040007F0 RID: 2032
         public Color fill;
         private bool altTexture;
-        public string altTextureString;
+        public Axes axes;
 
         // Token: 0x040007F1 RID: 2033
         private Level level;

--- a/Code/Entities/UninterruptedNRCB.cs
+++ b/Code/Entities/UninterruptedNRCB.cs
@@ -5,19 +5,30 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-
 namespace Celeste.Mod.CherryHelper
 {
     [CustomEntity("CherryHelper/UI_NRCB")]
     public class UninterruptedNRCB : Solid
     {
-
-        public UninterruptedNRCB(Vector2 position, float width, float height, Axes axes, bool chillOut = false, bool altTexture = false) : base(position, width, height, false)
+        private string spriteDirectory;
+        public UninterruptedNRCB(EntityData data, Vector2 offset) : base(data.Position + offset, data.Width, data.Height, false)
         {
-            
-            this.altTexture = altTexture;
-            this.fill = altTexture ? Calc.HexToColor("242262") : Calc.HexToColor("62222b");
-            altTextureString = (altTexture ? "objects/uninterruptedNRK/" : "objects/crushblock/");
+            axes = data.Enum("axes", Axes.Both);
+            chillOut = data.Bool("chillOut", false);
+
+            // Backwards compatibility for toggled texture
+            altTexture = data.Bool("altTexture", true);
+            if (altTexture)
+            {
+                spriteDirectory = data.Attr("spriteDirectory", "objects/uninterruptedNRK");
+                fill = Calc.HexToColor(data.Attr("fillColor", "242262"));
+            }
+            else
+            {
+                spriteDirectory = "objects/crushblock";
+                fill = Calc.HexToColor("62222b");
+            }
+
             this.idleImages = new List<Image>();
             this.activeTopImages = new List<Image>();
             this.activeRightImages = new List<Image>();
@@ -25,13 +36,12 @@ namespace Celeste.Mod.CherryHelper
             this.activeBottomImages = new List<Image>();
             this.OnDashCollide = new DashCollision(this.OnDashed);
             this.returnStack = new List<UninterruptedNRCB.MoveState>();
-            this.chillOut = chillOut;
             this.giant = (Width >= 48f && Height >= 48f && chillOut);
             this.canActivate = true;
             this.attackCoroutine = new Coroutine(true);
             this.attackCoroutine.RemoveOnComplete = false;
             Add(this.attackCoroutine);
-            List<MTexture> atlasSubtextures = GFX.Game.GetAtlasSubtextures(altTextureString + "block");
+            List<MTexture> atlasSubtextures = GFX.Game.GetAtlasSubtextures(spriteDirectory + "/block");
             MTexture idle;
             switch (axes)
             {
@@ -50,16 +60,42 @@ namespace Celeste.Mod.CherryHelper
                     this.canMoveVertically = true;
                     break;
             }
-            if (altTexture)
+            Add(face = new Sprite(GFX.Game, spriteDirectory + "/"));
+            if (giant)
             {
-                Add(this.face = GFX.SpriteBank.Create(this.giant ? "giant_UNoReturnKevin_face" : "UNoReturnKevin_face"));
+                /*
+                  <Loop id="idle" path="giant_block" frames="0" delay="0.08"/>
+                  <Anim id="hurt"  path="giant_block" frames="8-12" delay="0.08" goto="idle"/>
+                  <Anim id="hit" path="giant_block" frames="0-5" delay="0.08"/>
+                  <Loop id="right" path="giant_block" frames="6,7"  delay="0.08"/>
+                */
+                face.AddLoop("idle", "giant_block", 0.08f, 0);
+                face.Add("hurt", "giant_block", 0.08f, "idle", 8, 9, 10, 11, 12);
+                face.Add("hit", "giant_block", 0.08f, 0, 1, 2, 3, 4, 5);
+                face.AddLoop("right", "giant_block", 0.08f, 6, 7);
             }
             else
             {
-                Add(this.face = GFX.SpriteBank.Create(this.giant ? "giant_crushblock_face" : "crushblock_face"));
+                /*
+                  <Loop id="idle" path="idle_face" delay="0.08"/>
+                  <Anim id="hurt" path="hurt" frames="3-12" delay="0.08" goto="idle"/>
+                  <Anim id="hit" path="hit" delay="0.08"/>
+                  <Loop id="left" path="hit_left" delay="0.08"/>
+                  <Loop id="right" path="hit_right" delay="0.08"/>
+                  <Loop id="up" path="hit_up" delay="0.08"/>
+                  <Loop id="down" path="hit_down" delay="0.08"/>
+                */
+
+                face.AddLoop("idle", "idle_face", 0.08f);
+                face.Add("hurt", "hurt", 0.08f, "idle", 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+                face.Add("hit", "hit", 0.08f);
+                face.AddLoop("left", "hit_left", 0.08f);
+                face.AddLoop("right", "hit_right", 0.08f);
+                face.AddLoop("up", "hit_up", 0.08f);
+                face.AddLoop("down", "hit_down", 0.08f);
             }
-            this.face.Position = new Vector2(Width, Height) / 2f;
-            this.face.Play("idle", false, false);
+            face.CenterOrigin();
+            face.Play("idle");
             this.face.OnLastFrame = delegate (string f)
             {
                 bool flag = f == "hit";
@@ -87,11 +123,6 @@ namespace Celeste.Mod.CherryHelper
             Add(new LightOcclude(0.2f));
             Add(this.returnLoopSfx = new SoundSource());
             Add(new WaterInteraction(() => this.crushDir != Vector2.Zero));
-        }
-
-        public UninterruptedNRCB(EntityData data, Vector2 offset) : this(data.Position + offset, (float)data.Width, (float)data.Height, data.Enum<UninterruptedNRCB.Axes>("axes", Axes.Both), data.Bool("chillout", false), data.Bool("altTexture", false))
-        {
-            
         }
 
         public override void Added(Scene scene)
@@ -194,7 +225,7 @@ namespace Celeste.Mod.CherryHelper
                 bool flag4 = borderX < 0;
                 if (flag4)
                 {
-                    Image image2 = new Image(GFX.Game[altTextureString + "lit_left"].GetSubtexture(0, ty * 8, 8, 8, null));
+                    Image image2 = new Image(GFX.Game[spriteDirectory + "/lit_left"].GetSubtexture(0, ty * 8, 8, 8, null));
                     this.activeLeftImages.Add(image2);
                     image2.Position = vector;
                     image2.Visible = false;
@@ -205,7 +236,7 @@ namespace Celeste.Mod.CherryHelper
                     bool flag5 = borderX > 0;
                     if (flag5)
                     {
-                        Image image3 = new Image(GFX.Game[altTextureString + "lit_right"].GetSubtexture(0, ty * 8, 8, 8, null));
+                        Image image3 = new Image(GFX.Game[spriteDirectory + "/lit_right"].GetSubtexture(0, ty * 8, 8, 8, null));
                         this.activeRightImages.Add(image3);
                         image3.Position = vector;
                         image3.Visible = false;
@@ -215,7 +246,7 @@ namespace Celeste.Mod.CherryHelper
                 bool flag6 = borderY < 0;
                 if (flag6)
                 {
-                    Image image4 = new Image(GFX.Game[altTextureString + "lit_top"].GetSubtexture(tx * 8, 0, 8, 8, null));
+                    Image image4 = new Image(GFX.Game[spriteDirectory + "/lit_top"].GetSubtexture(tx * 8, 0, 8, 8, null));
                     this.activeTopImages.Add(image4);
                     image4.Position = vector;
                     image4.Visible = false;
@@ -226,7 +257,7 @@ namespace Celeste.Mod.CherryHelper
                     bool flag7 = borderY > 0;
                     if (flag7)
                     {
-                        Image image5 = new Image(GFX.Game[altTextureString + "lit_bottom"].GetSubtexture(tx * 8, 0, 8, 8, null));
+                        Image image5 = new Image(GFX.Game[spriteDirectory + "/lit_bottom"].GetSubtexture(tx * 8, 0, 8, 8, null));
                         this.activeBottomImages.Add(image5);
                         image5.Position = vector;
                         image5.Visible = false;
@@ -753,7 +784,7 @@ namespace Celeste.Mod.CherryHelper
         private const float ReturnAccel = 80f;
         public Color fill;
         private bool altTexture;
-        public string altTextureString;
+        public Axes axes;
 
         private Level level;
 

--- a/Graphics/Sprites.xml
+++ b/Graphics/Sprites.xml
@@ -1,25 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Sprites>
-  <NoReturnKevin_face path="objects/noReturnKevin/" start="idle">
-      <Center/>
-      <Loop id="idle" path="idle_face" delay="0.08"/>
-      <Anim id="hurt" path="hurt" frames="3-12" delay="0.08" goto="idle"/>
-      <Anim id="hit" path="hit" delay="0.08"/>
-      <Loop id="left" path="hit_left" delay="0.08"/>
-      <Loop id="right" path="hit_right" delay="0.08"/>
-      <Loop id="up" path="hit_up" delay="0.08"/>
-      <Loop id="down" path="hit_down" delay="0.08"/>
-  </NoReturnKevin_face>
-  <UNoReturnKevin_face path="objects/uninterruptedNRK/" start="idle">
-      <Center/>
-      <Loop id="idle" path="idle_face" delay="0.08"/>
-      <Anim id="hurt" path="hurt" frames="3-12" delay="0.08" goto="idle"/>
-      <Anim id="hit" path="hit" delay="0.08"/>
-      <Loop id="left" path="hit_left" delay="0.08"/>
-      <Loop id="right" path="hit_right" delay="0.08"/>
-      <Loop id="up" path="hit_up" delay="0.08"/>
-      <Loop id="down" path="hit_down" delay="0.08"/>
-  </UNoReturnKevin_face>
   <NoReturnSokoban_face path="objects/noReturnSokoban/" start="idle">
       <Center/>
       <Loop id="idle" path="idle_face" delay="0.08"/>


### PR DESCRIPTION
- Edited Ahorn plugin to allow for customizable fill colors + sprite directories and render correctly
- Backwards compatibility logic for older entities that still use the altTexture toggle
- Sprite building logic for the face sprite, removed old sprite from XML

Decided not to restructure the entities, it was leading me towards a much bigger rework. This way it's a bit more maintainable for you anyway. Let me know if you have any questions! I tested it in Ahorn with old versions of the entities + new versions, backwards compatibility logic renders everything correctly.