### PR TITLE
Fixes Kevin face bug

### DIFF
--- a/Code/Entities/NonReturnCrushBlock.cs
+++ b/Code/Entities/NonReturnCrushBlock.cs
@@ -61,6 +61,7 @@ namespace Celeste.Mod.CherryHelper
                     break;
             }
             Add(face = new Sprite(GFX.Game, spriteDirectory + "/"));
+            face.Position = new Vector2(Width, Height) / 2f;
             if (giant)
             {
                 /*

--- a/Code/Entities/UninterruptedNRCB.cs
+++ b/Code/Entities/UninterruptedNRCB.cs
@@ -61,6 +61,7 @@ namespace Celeste.Mod.CherryHelper
                     break;
             }
             Add(face = new Sprite(GFX.Game, spriteDirectory + "/"));
+            face.Position = new Vector2(Width, Height) / 2f;
             if (giant)
             {
                 /*


### PR DESCRIPTION
Not setting position causes Kevin's face sprite to start in top-left on transition and snap into place after an update